### PR TITLE
Clarify public repo operating model and new-Mac bootstrap lanes

### DIFF
--- a/ARCHIVE_PROJECT_INTERFACE.md
+++ b/ARCHIVE_PROJECT_INTERFACE.md
@@ -10,6 +10,34 @@ This document applies to projects such as:
 
 The top-level site is the Steven Woods hub shell. The archive projects are the deep historical archives.
 
+## Maintenance Model
+
+These archive projects are currently shared-public subprojects, not default
+standalone repos.
+
+The preferred active working model on the newer machine is:
+
+- one canonical clone at `~/Projects-All/public`
+- shared-public subprojects maintained inside that clone
+
+That means the default active home for projects such as:
+
+- `canberra-research`
+- `google-canada-research`
+- `inovia-research`
+- `sei-pittsburgh-research`
+- `steven-woods-research`
+- `quack`
+- `kinitos-neoedge`
+
+is inside the canonical `public` repo unless we deliberately split one out into
+its own repository later.
+
+Older sparse or single-purpose local clones of those subprojects should be
+treated as legacy transitional patterns. Reconcile any unique work they contain
+before deleting or normalizing them, but do not treat them as the preferred
+ongoing model.
+
 ## Ownership model
 
 Use this split consistently:
@@ -100,6 +128,13 @@ Each archive project should maintain and publish three machine-readable files:
 3. `public-handoff.json`
 
 These may live in the archive project repo itself, but their contents are intended for `public` to consume.
+
+For shared-public subprojects that still live inside `public`, these files are
+the canonical machine-readable export lane.
+
+Do not create new `data/projects/*.json` records for archive subprojects by
+default. Use that standalone-project lane only when a documented bridge or
+compatibility reason exists.
 
 ## Project manifest
 

--- a/PROJECT-STATE-AND-RECOVERY.md
+++ b/PROJECT-STATE-AND-RECOVERY.md
@@ -1,0 +1,487 @@
+# Public project state and recovery
+
+Updated: 2026-05-07
+
+## Current recommended working model
+
+This section supersedes the earlier recovery-only framing below.
+
+The durable source of truth for this repo is:
+
+- GitHub repo: `https://github.com/sgwoods/public.git`
+
+The preferred active clone model going forward is:
+
+- canonical active shared-public clone on the newer machine:
+  - `~/Projects-All/public`
+
+Use that clone as the default home for:
+
+- top-level shared navigation/reporting work
+- standalone project exports that publish into `public`
+- shared-public subprojects such as `steven-woods-research`, `quack`, and `kinitos-neoedge`
+
+Important distinction:
+
+- `public-quack-recovery` remains a continuity and reconciliation lane
+- it is not the preferred default active clone model for ongoing shared-public work
+- `/Users/stevenwoods/GitPages/public` remains a deprecated transition checkout
+
+Read the remaining sections in this file as the history of the recovery pass
+that created the continuity lane, not as the final long-term clone model.
+
+## Historical recovery policy
+
+During the recovery pass, the working policy was that local work should happen
+only in an iCloud-backed folder.
+
+Current state:
+
+- canonical active continuity checkout:
+  - `/Users/stevenwoods/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public-quack-recovery`
+- older non-iCloud transition checkout:
+  - `/Users/stevenwoods/GitPages/public`
+- parallel older iCloud checkout:
+  - `/Users/stevenwoods/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public`
+
+Practical implication:
+
+- `public-quack-recovery` is the current active continuity workspace
+- `/Users/stevenwoods/GitPages/public` should be treated as a deprecated transition checkout for active local work
+- `/Users/stevenwoods/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public` should be treated as a non-canonical parallel iCloud checkout unless intentionally reconciled later
+- no new substantial local-only work should continue in deprecated or non-canonical checkouts
+- new-machine bootstrap and validation instructions now live in `START-HERE-NEW-MAC.md` and `tools/start_codex_on_new_mac.sh`
+
+## Parallel workstreams
+
+Several active projects are being worked on separately and in parallel to this continuity effort.
+
+At the time of this update, those parallel workstreams include:
+
+- `phd-renovation`
+- `ai-dystopia-quotes`
+- `mmath-renovation`
+- `kinitos-neoedge`
+- `quack`
+
+Operational rule:
+
+- the continuity/recovery branch should not casually absorb active project work from those streams just because their files are locally modified
+- project-specific work should remain grouped by project and handled intentionally
+- continuity work should focus on:
+  - recovery notes
+  - workflow baselines
+  - archive coordination surfaces
+  - migration readiness
+
+This changes the stabilization strategy:
+
+- do not treat all local modifications as one cleanup batch
+- instead, separate `continuity infrastructure` from `active project development or research`
+- preserve continuity-first work here, while leaving parallel project changes for their own deliberate batching
+
+## Living plan
+
+This is the current working plan and should be kept up to date as work proceeds.
+
+### Phase 1: stabilize the current local state
+
+Status: `partially complete`
+
+Goals:
+
+- protect current local-only work from accidental loss
+- make the current workspace auditable
+- avoid introducing more divergence before migration
+- avoid accidentally co-mingling unrelated parallel project work under the recovery branch
+
+Tasks:
+
+- [x] create a dedicated recovery branch from the current local state
+- [x] commit the currently untracked continuity files
+- [ ] group and commit the remaining tracked local modifications intentionally
+- [x] separate Quack continuity-only changes from active parallel project changes
+- [ ] remove or ignore Finder junk such as `.DS_Store`
+- [ ] fetch/review and reconcile the current `origin/main` gap
+
+### Phase 2: iCloud migration
+
+Status: `complete for Quack continuity workspace`
+
+Goals:
+
+- move the active working copy into an iCloud-backed location
+- ensure new machine recovery does not depend on the old non-iCloud checkout
+
+Tasks:
+
+- [x] choose the canonical iCloud-backed parent folder for active repos
+- [x] create a fresh clone of this repo in the iCloud-backed location
+- [x] verify the Quack continuity checkout can build/regenerate its archive surfaces
+- [x] move Quack continuity work into that canonical checkout via the recovery branch
+- [x] stop treating `/Users/stevenwoods/GitPages/public` as the primary Quack working copy
+
+### Phase 3: continuity hardening
+
+Status: `in progress`
+
+Goals:
+
+- make a fresh checkout sufficient to continue work
+- reduce dependence on transient web sources and machine-local memory
+
+Tasks:
+
+- [x] add a top-level bootstrap checklist for a new machine
+- [ ] add a regeneration checklist for derived pages and indexes
+- [ ] audit source manifests for local mirror coverage
+- [ ] classify artifacts as canonical, derived, or scratch
+- [ ] make continuity documents part of the normal publishing discipline
+
+### Phase 4: repo separation
+
+Status: `not started`
+
+Goals:
+
+- reduce coupling between independent archive efforts
+- keep `public` focused on the hub, rendering, and downstream summaries
+
+Tasks:
+
+- [ ] separate `quack` into its own canonical repo when continuity is stable
+- [ ] separate `kinitos-neoedge` into its own canonical repo when continuity is stable
+- [ ] separate `steven-woods-research` into its own canonical repo when continuity is stable
+- [ ] keep era archives nested until they justify their own repositories
+
+## Precise goal
+
+This repository is the public-facing Steven Woods hub and archive shell.
+
+Its job is to:
+
+- publish the top-level public site
+- hold the recovered `Spectra` historical material
+- render the shared project dashboard from project manifests
+- host the person-centric Steven Woods archive
+- host or mirror several company- and era-centric research archives
+- keep enough checked-in structure, data, and workflow guidance that archive work can resume on a new machine without rediscovery
+
+This repo is not just a website. It is also the continuity surface for several related archive and research efforts.
+
+## Current canonical working areas
+
+These are the current canonical working areas inside this repo:
+
+- `Spectra/` for the recovered historical site archive
+- `steven-woods-research/` for the person-centric deep archive
+- `quack/` for the canonical Quack deep archive
+- `kinitos-neoedge/` for the canonical Kinitos / NeoEdge deep archive
+- `google-canada-research/`, `inovia-research/`, `canberra-research/`, and `sei-pittsburgh-research/` as early era-archive shells
+- top-level public pages and renderers under the repo root and `tools/`
+
+These are the areas that should be treated as current working surfaces unless later documents explicitly replace them.
+
+Workspace-status references:
+
+- `quack/WORKSPACE-STATUS.md`
+- `kinitos-neoedge/WORKSPACE-STATUS.md`
+- `START-HERE-NEW-MAC.md`
+
+## Legacy, alias, or supporting areas
+
+These paths are not the canonical deep working areas, even if they still exist and remain useful:
+
+- `data/kinitos-neoedge/`
+  - legacy/supporting intake scaffold
+  - useful for continuity and earlier intake context
+  - not the canonical deep archive root
+- `data/projects/codex-test1.json`
+  - legacy compatibility alias for Aurora Galactica
+  - not the canonical active project identity
+- `/Users/stevenwoods/GitPages/public`
+  - deprecated transition checkout for active local archive work
+  - not the intended long-term canonical local working copy
+- `/Users/stevenwoods/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public`
+  - non-canonical parallel iCloud checkout
+  - useful only if intentionally reconciled later
+
+Rule:
+
+- if a path is canonical, work should accumulate there
+- if a path is legacy/supporting, it should be labeled and used only for continuity, intake history, or compatibility
+- if a path becomes abandoned, mark it explicitly rather than leaving it ambiguous
+
+## Current state
+
+- tracked files: about `3110`
+- top-level archive payload:
+  - `Spectra/` about `84M`
+  - `quack/` about `1.5M`
+  - `steven-woods-research/` about `4.8M`
+  - `kinitos-neoedge/` about `272K`
+  - era archives (`google-canada-research/`, `inovia-research/`, `canberra-research/`, `sei-pittsburgh-research/`) are present as structured shells
+- shared coordination documents exist:
+  - `ARCHIVE_PROJECT_INTERFACE.md`
+  - `PUBLIC_STATUS_INTERFACE.md`
+  - `data/shared/incoming-artifact-analysis-playbook.md`
+  - `data/shared/incoming-artifact-analysis-template.md`
+
+Top-level active project-manifest feeds currently exist for:
+
+- `data/projects/aurora-galactica.json`
+- `data/projects/codex-test1.json` (legacy alias)
+- `data/projects/phd-renovation.json`
+- `data/projects/mmath-renovation.json`
+- `data/projects/quack-com.json`
+- `data/projects/kinitos-neoedge.json`
+- `data/projects/confidential-project.json`
+- `data/projects/ai-dystopia-quotes.json`
+
+Archive-style project manifests currently exist for:
+
+- `steven-woods-research/project-manifest.json`
+- `quack/project-manifest.json`
+- `kinitos-neoedge/project-manifest.json`
+- `google-canada-research/project-manifest.json`
+- `inovia-research/project-manifest.json`
+- `canberra-research/project-manifest.json`
+- `sei-pittsburgh-research/project-manifest.json`
+
+## Current status
+
+The continuity story is now materially better than it was at the start of this pass, but there is still an important split between:
+
+- the **safe continuity lane**, which is checked in and iCloud-backed
+- the **deprecated MacBook checkout**, which still contains unrelated active project edits
+
+Current continuity reality:
+
+- branch: `codex/public-recovery-stabilization`
+- remote tracking branch for that lane exists and is current
+- canonical active continuity checkout:
+  - `/Users/stevenwoods/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public-quack-recovery`
+- older iCloud checkout on `main` also exists and is clean:
+  - `/Users/stevenwoods/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public`
+- deprecated non-iCloud checkout still has local modifications from active parallel work:
+  - `/Users/stevenwoods/GitPages/public`
+
+What we can now honestly claim:
+
+- a new machine can clone the recovery branch into an iCloud-backed workspace and validate it from checked-in instructions
+- Quack and Kinitos continuity can restart from the canonical iCloud-backed recovery checkout without relying on memory from this MacBook
+- the portability path is documented and scripted
+
+What we still cannot honestly claim:
+
+- that every active parallel project change in the deprecated MacBook checkout is already folded into the continuity lane
+- that the deprecated checkout itself should be treated as canonical
+
+## What is checked in now
+
+Checked in and reusable from a clean clone:
+
+- top-level public site pages and renderer
+- `Spectra/` recovered archive tree
+- Steven Woods public profile, CV, and research surfaces
+- the archive/research directory shells
+- many mirrored source artifacts under `Spectra/`, `steven-woods-research/`, and `quack/`
+- manifest-driven project card system
+- charting and dashboard rendering logic
+- shared archive coordination and workflow docs
+- project-specific archive structure for:
+  - `quack`
+  - `kinitos-neoedge`
+  - `steven-woods-research`
+  - `google-canada-research`
+  - `inovia-research`
+  - `canberra-research`
+  - `sei-pittsburgh-research`
+
+Notable continuity-positive signals:
+
+- Quack already has a dedicated checked-in recovery note at `quack/PROJECT-STATE-AND-RECOVERY.md`
+- shared workflow guidance exists at `data/shared/company-research-workflow.md`
+- person/archive contract guidance exists in `ARCHIVE_PROJECT_INTERFACE.md`
+
+## What is not safely checked in yet
+
+### Local tracked modifications
+
+The deprecated non-iCloud checkout still has tracked local modifications that are not part of the clean continuity snapshot.
+
+At the time of this update, those modified areas include:
+
+- `ai-dystopia-quotes`
+- `phd-renovation`
+- `mmath-renovation`
+- some top-level derived or presentation files such as `index.html` and `steven-woods-cv.pdf`
+
+Important note:
+
+- these are active parallel project surfaces
+- they should be grouped and handled in their own project flows
+- they are not proof that the continuity lane is broken
+- they are proof that `/Users/stevenwoods/GitPages/public` is not the canonical workspace anymore
+
+### Local untracked files
+
+The continuity bootstrap surfaces should be checked in and preferred over ad hoc local notes.
+
+If new untracked bootstrap or portability files appear in the deprecated checkout, treat that as a warning sign:
+
+- either the file should be intentionally promoted into the continuity lane
+- or it should be removed as scratch or duplicate material
+
+### Local machine residue
+
+The repo still contains Finder metadata in multiple places such as:
+
+- `.DS_Store`
+- `quack/.DS_Store`
+- `kinitos-neoedge/.DS_Store`
+- `Spectra/.DS_Store`
+- `google-canada-research/.DS_Store`
+- `inovia-research/.DS_Store`
+- `canberra-research/.DS_Store`
+
+These do not help continuity and should not be part of the recovery story.
+
+Current hygiene rule:
+
+- `.DS_Store`, `__pycache__/`, `*.pyc`, and AppleDouble files should be ignored and treated as non-project residue
+
+## Artifact-state assessment
+
+### Good
+
+- `Spectra/` appears substantially preserved inside the repo
+- the Steven Woods research archive has structured source manifests and preserved captures
+- Quack has emerging self-contained workflow, source, and recovery surfaces
+- archive project folders follow a repeatable interface pattern
+
+### Incomplete
+
+- not all external sources have local mirrors
+- some research notes still depend on canonical web URLs instead of preserved local copies
+- several active areas are only partially checked in because the current working tree is dirty
+- remote `origin/main` is ahead of the local checkout, so this local workspace is not even the full checked-in truth as of today
+
+### Continuity conclusion
+
+If the deprecated non-iCloud checkout vanished today, we would still retain the continuity lane because:
+
+- the recovery branch is pushed
+- the canonical continuity checkout is already in iCloud-backed storage
+- the bootstrap and validation path is documented
+
+What would still be at risk are only the active parallel project edits that remain local to the deprecated checkout and have not yet been grouped into their own project-specific commits.
+
+## Recommended next steps to reach recovery certainty
+
+### Immediate
+
+1. Keep the continuity lane on `codex/public-recovery-stabilization` clean and pushed.
+2. Treat `/Users/stevenwoods/GitPages/public` as deprecated for new work.
+3. Move active project continuation into iCloud-backed checkouts only.
+4. Promote only deliberate portability surfaces into the continuity lane.
+5. Remove duplicate local bootstrap or scratch files that are no longer authoritative.
+
+### After that
+
+6. Add a top-level regeneration checklist for:
+   - homepage rendering
+   - Steven source index rendering
+   - Quack research pipeline runs
+   - any archive-page generation steps
+7. Audit all `source-manifest.json` files for local-archive coverage and mark:
+   - mirrored locally
+   - canonical external only
+   - needs local preservation
+8. Decide which artifacts are canonical repo content versus machine-local scratch output.
+9. Keep `README.md`, `START-HERE-NEW-MAC.md`, and `LOCAL-WORKTREE-STATUS.md` aligned so a new machine has one obvious startup path.
+
+## Recommended next steps for the project itself
+
+1. Stabilize repository continuity before adding more historical content.
+2. Keep continuity-specific commits separate from active parallel project commits.
+3. Bring the local checkout up to date with `origin/main` in a controlled way.
+4. Migrate active work to an iCloud-backed clone and treat that as canonical.
+5. Resume each parallel project from the iCloud-backed workspace in its own grouped flow.
+6. Continue source preservation, prioritizing fragile or high-value external sources.
+7. Tighten the contract between project manifests and rendered public pages so stale exports are easier to detect.
+
+## Subprojects that should be separated
+
+### Strong candidates for separation
+
+These have enough identity and independent pace to justify their own repos over time:
+
+- `quack`
+- `kinitos-neoedge`
+- `steven-woods-research`
+
+Why:
+
+- they have their own manifests
+- they have their own research or archive workflow
+- they change independently
+- they are larger than simple public-page subfolders
+
+Recommended separation model:
+
+- each becomes its own canonical repo
+- each continues to publish `project-manifest.json`, `source-manifest.json`, and `public-handoff.json`
+- this `public` repo becomes the downstream hub and published shell
+
+### Likely stay nested for now
+
+- `google-canada-research`
+- `inovia-research`
+- `canberra-research`
+- `sei-pittsburgh-research`
+
+Why:
+
+- they are still early shells
+- they are not yet heavy enough to justify separate repositories
+- they can remain nested under the Steven-centric archive until their preserved material and independent workflows grow
+
+### Likely stay in this repo
+
+- `Spectra/`
+- top-level profile/publication/reference pages
+- homepage/dashboard rendering
+- shared interface and workflow docs
+
+Why:
+
+- these are part of the public hub itself
+- they are downstream presentation and shared infrastructure, not independent archival identities
+
+## Recommended structure direction
+
+Best long-term shape:
+
+- `public` = public hub, shared pages, renderers, reference docs, and downstream published summaries
+- `quack` = independent company archive repo
+- `kinitos-neoedge` = independent company archive repo
+- `steven-woods-research` = independent person-centric archive repo
+- era subprojects remain inside `steven-woods-research` until they justify splitting
+
+## Bottom-line assessment
+
+Today the project is valuable, substantial, and partly structured for continuity, but it is **not yet at the standard where we should say a new machine can reproduce the exact current state without loss**.
+
+To reach that bar, the next unit of work should be continuity and repository hygiene, not more discovery.
+
+With the new iCloud-backed-work requirement, the next unit of work is more specifically:
+
+- stabilize current local state
+- migrate the canonical working copy into iCloud-backed storage
+- then continue archive and research expansion only from that backed-up checkout
+
+Because several substantive projects are moving in parallel, the correct interpretation is:
+
+- continuity work should make those parallel streams safer
+- continuity work should not replace their own project-specific batching and decision-making

--- a/PUBLIC-OPERATING-MODEL.md
+++ b/PUBLIC-OPERATING-MODEL.md
@@ -1,0 +1,179 @@
+# Public Repo Operating Model
+
+Updated: `2026-05-07`
+
+This file defines the intended ongoing role of `sgwoods/public`.
+
+The key rule is simple:
+
+- this repo is the shared Woods presentation, reporting, and coordination layer
+- it is not just another standalone project repo
+- other projects may publish into it, but they should not redefine its structure ad hoc
+
+## What this repo is for
+
+`sgwoods/public` is the top-level shared public layer for:
+
+- cross-project summary and navigation
+- shared public presentation
+- ingestion and reporting coordination
+- selected public-facing exports from standalone repos
+- shared-public research/archive subprojects that still live inside this repo
+- durable public/archive assets that belong to the common Woods layer rather than to one standalone repo
+
+The default public starting point is:
+
+- `index.html`
+
+That page should remain the one clear place to:
+
+- see project summaries
+- see current status/focus for active projects
+- link out to deeper project pages, dashboards, handbooks, and archive sections
+
+## Structure classes
+
+Use these classes consistently when deciding where work belongs.
+
+| Class | What it contains | Current examples | Ownership model |
+| --- | --- | --- | --- |
+| Shared navigation and reporting layer | Cross-project homepage, shared assets, shared renderers, shared workflow docs | `index.html`, `assets/`, `tools/render_index.py`, `data/shared/`, `README.md`, `PUBLIC_STATUS_INTERFACE.md`, `ARCHIVE_PROJECT_INTERFACE.md` | Owned by the `public` repo itself |
+| Standalone project exports and summary cards | Public pages and status manifests published in from true standalone repos | `data/projects/aurora-galactica.json`, `data/projects/phd-renovation.json`, `data/projects/mmath-renovation.json`, `data/projects/ai-dystopia-quotes.json`, top-level pages such as `phd-renovation.html`, `phd-renovation-dashboard.html`, `phd-renovation-handbook.html`, `mmath-renovation.html`, `aurora-galactica.html` | Owned by the originating standalone repo; `public` only renders and presents them |
+| Shared-public subprojects | Deep archive/research areas that still live inside `public` as subdirectories | `steven-woods-research/`, `quack/`, `kinitos-neoedge/`, `canberra-research/`, `google-canada-research/`, `inovia-research/`, `sei-pittsburgh-research/` plus their top-level landing pages | Maintained inside the canonical `public` clone unless deliberately split into separate repos later |
+| Legacy, compatibility, or deprecated patterns | Transitional aliases, duplicate publication paths, or older local clone habits that should not expand casually | `data/projects/codex-test1.json`, `codex-test1.html`, the bridge `data/projects/quack-com.json`, the bridge `data/projects/kinitos-neoedge.json`, older sparse single-purpose local clones of `public`, deprecated `/Users/stevenwoods/GitPages/public` checkout, recovery-only iCloud clone conventions | Keep only when needed for continuity or compatibility; label them clearly |
+
+## Ongoing ownership model
+
+### 1. Shared top-level layer
+
+`public` owns:
+
+- homepage rendering
+- shared navigation wording
+- card ordering
+- shared CSS/JS/assets
+- shared ingestion/reporting docs
+- rules for how other projects publish into this layer
+
+### 2. Standalone repos
+
+A true standalone repo owns:
+
+- its own durable Git history
+- its own detailed docs and status logic
+- its own dashboard or handbook generation
+- its own exported status facts
+
+The standalone repo may publish selected outputs into `public`, but it should only write:
+
+- its own top-level public page(s)
+- its own canonical `data/projects/<project>.json`
+- any intentionally owned exported artifacts for that project
+
+It should not directly edit shared homepage presentation logic.
+
+### 3. Shared-public subprojects
+
+A shared-public subproject owns:
+
+- its own subdirectory content inside this repo
+- its own top-level landing page in the repo root
+- its own `project-manifest.json`
+- its own `source-manifest.json`
+- its own `public-handoff.json`
+
+Those subprojects should not automatically create or depend on separate top-level clones under `Projects-All`.
+
+The default model is:
+
+- one canonical `public` clone
+- multiple named subproject directories inside it
+
+If one of those subprojects is later split into its own standalone repo, document that decision explicitly and update its ownership and publishing rules at the same time.
+
+## Preferred active clone model
+
+For the newer machine and for ongoing work going forward, the preferred active clone is:
+
+- `~/Projects-All/public`
+
+Interpretation:
+
+- `Projects-All/public` is the canonical active working clone for the shared public layer
+- true standalone repos should each have their own sibling working clone under `Projects-All`
+- shared-public subprojects should normally be edited inside `Projects-All/public`
+- do not casually create extra top-level clones for `quack`, `steven-woods-research`, `google-canada-research`, and similar subprojects unless there is a deliberate operational reason
+
+Recommended `Projects-All` shape:
+
+```text
+~/Projects-All/
+  public
+  phd-renovation-working
+  mmath-renovation-working
+  sci-fi-ai-dystopian-project-working
+  Codex-Test1
+  abtweak-experiments-ui
+```
+
+The exact sibling repo names can vary, but the category split should stay the same.
+
+## Publishing model
+
+### Standalone repo into public
+
+Default flow:
+
+1. Update the standalone repo.
+2. Generate or refresh its own public-facing outputs.
+3. Sync only the owned exported artifacts into `public`.
+4. Let `public` render the homepage from those published facts.
+
+The usual `public` export lane for a standalone repo is:
+
+- `data/projects/<project>.json`
+- top-level project page(s) owned by that repo
+
+### Shared-public subproject inside public
+
+Default flow:
+
+1. Work inside the canonical `public` clone.
+2. Update the subproject directory and its top-level landing page.
+3. Refresh `project-manifest.json`, `source-manifest.json`, and `public-handoff.json` as needed.
+4. Let the shared `public` navigation and homepage surface those materials coherently.
+
+The default export lane for a shared-public subproject is:
+
+- `<subproject>/project-manifest.json`
+- `<subproject>/source-manifest.json`
+- `<subproject>/public-handoff.json`
+
+Do not create new `data/projects/*.json` entries for shared-public subprojects unless there is a documented compatibility reason.
+
+## Duplicate and bridge rules
+
+Some duplicate paths exist today for compatibility.
+
+Current examples:
+
+- `codex-test1` is a legacy compatibility alias for `aurora-galactica`
+- `quack-com` and `kinitos-neoedge` currently appear both as shared-public subprojects and as bridge records in `data/projects/`
+
+Treat these as bridge patterns, not as the preferred default for new work.
+
+When a duplicate exists, document which copy is:
+
+- canonical
+- compatibility-only
+- temporary bridge logic
+
+## Big-picture rule
+
+We want one durable pattern:
+
+- standalone repo truth stays in the standalone repo
+- shared-public subproject truth stays inside the canonical `public` clone
+- `public` remains the one cross-project public summary and presentation layer
+
+That is the model to preserve as more projects move into `Projects-All`.

--- a/PUBLIC_STATUS_INTERFACE.md
+++ b/PUBLIC_STATUS_INTERFACE.md
@@ -20,6 +20,40 @@ To make that work:
 - each project owns only its own status manifest
 - the `public` repo owns homepage rendering and homepage wording
 
+## Scope Boundary
+
+This document applies to true standalone projects that publish summary/status
+into `public`.
+
+Examples:
+
+- `aurora-galactica`
+- `phd-renovation`
+- `mmath-renovation`
+- `ai-dystopia-quotes`
+
+This document is not the default publishing contract for shared-public
+subprojects such as:
+
+- `steven-woods-research`
+- `quack`
+- `kinitos-neoedge`
+- `canberra-research`
+- `google-canada-research`
+- `inovia-research`
+- `sei-pittsburgh-research`
+
+Those subprojects live inside the shared `public` repo and should normally
+publish through their own subdirectory manifests:
+
+- `project-manifest.json`
+- `source-manifest.json`
+- `public-handoff.json`
+
+If a shared-public subproject also has a `data/projects/*.json` record today,
+that should be treated as an explicit bridge or compatibility layer, not as the
+preferred default for new subproject work.
+
 ## Rule
 
 Each project may update:
@@ -39,21 +73,33 @@ status manifests.
 
 ## Status Manifest Ownership
 
-Each active project owns exactly one canonical file under `data/projects/`.
-Legacy compatibility aliases may exist, but they must stay inactive so they do
-not create duplicate homepage entries.
+Each standalone project owns exactly one canonical file under `data/projects/`.
+Legacy compatibility aliases may exist, and shared-public bridge records may
+exist, but they should stay clearly labeled so they do not create accidental
+ownership confusion.
 
-Current canonical files:
+Current canonical standalone-project files:
 
 - `data/projects/aurora-galactica.json`
 - `data/projects/phd-renovation.json`
 - `data/projects/mmath-renovation.json`
+- `data/projects/ai-dystopia-quotes.json`
+- `data/projects/confidential-project.json`
+
+Current bridge records that are still consumed by the homepage but are not the
+preferred default model for shared-public subprojects:
+
+- `data/projects/quack-com.json`
+- `data/projects/kinitos-neoedge.json`
 
 Current compatibility alias files:
 
 - `data/projects/codex-test1.json`
 
-Only the owning project may write its file.
+Only the owning project may write its canonical file.
+
+For bridge records, keep ownership and purpose explicit. Do not add new bridge
+records casually.
 
 ## Required JSON Schema
 
@@ -155,6 +201,8 @@ The `public` repo owns the homepage renderer.
 That renderer will:
 
 - read all `data/projects/*.json`
+- combine them with the selected shared-public `project-manifest.json` inputs
+  described in `ARCHIVE_PROJECT_INTERFACE.md`
 - include only records where `active` is `true`
 - render homepage entries in a fixed order
 - compute the homepage "Repository work last updated" value from the maximum

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-Public information created by Steven Woods
+# Public information created by Steven Woods
+
+This repository is the shared Steven Woods public hub, reporting layer, and coordination surface across multiple projects.
+
+It is not just a standalone project site. Its job is to provide one clear public entry point for:
+
+- cross-project summaries and status
+- shared navigation and presentation
+- published exports from standalone repos
+- shared-public archive and research subprojects that still live inside this repo
+
+Start here on any machine:
+
+- [PUBLIC-OPERATING-MODEL.md](/Users/stevenwoods/GitPages/public/PUBLIC-OPERATING-MODEL.md)
+- [PROJECT-STATE-AND-RECOVERY.md](/Users/stevenwoods/GitPages/public/PROJECT-STATE-AND-RECOVERY.md)
+- [START-HERE-NEW-MAC.md](/Users/stevenwoods/GitPages/public/START-HERE-NEW-MAC.md)
+- [LOCAL-WORKTREE-STATUS.md](/Users/stevenwoods/GitPages/public/LOCAL-WORKTREE-STATUS.md)
+- [ARCHIVE_PROJECT_INTERFACE.md](/Users/stevenwoods/GitPages/public/ARCHIVE_PROJECT_INTERFACE.md)
+- [PUBLIC_STATUS_INTERFACE.md](/Users/stevenwoods/GitPages/public/PUBLIC_STATUS_INTERFACE.md)
+
+Current important rule:
+
+- the preferred active clone on the newer machine is `~/Projects-All/public`
+- this `/Users/stevenwoods/GitPages/public` checkout is transitional and should be treated as a historical bridge checkout
+- older iCloud recovery clones remain useful for continuity and reconciliation, but they are not the preferred default active clone model for ongoing shared-public work

--- a/START-HERE-NEW-MAC.md
+++ b/START-HERE-NEW-MAC.md
@@ -1,0 +1,222 @@
+# Start Here On A New Mac
+
+Updated: `2026-05-09`
+
+This file is the portability handoff for bringing the `public` continuity workspace onto a different Mac without relying on memory from the retiring MacBook.
+
+## Preferred active clone model
+
+For ongoing day-to-day work on the newer machine, the preferred active clone is:
+
+- `~/Projects-All/public`
+
+Use that clone as the default home for:
+
+- top-level shared public navigation/reporting work
+- shared-public subprojects such as `quack`, `kinitos-neoedge`, and `steven-woods-research`
+- integration of published exports from standalone repos
+
+Important distinction:
+
+- `tools/start_codex_on_new_mac.sh setup` now bootstraps the preferred active clone
+- `tools/start_codex_on_new_mac.sh setup-recovery` bootstraps the older continuity/recovery lane
+- the recovery lane remains useful for continuity and reconciliation, but it is no longer the default path
+
+If you are setting up the normal active clone, the default shape is:
+
+```bash
+mkdir -p ~/Projects-All
+git clone https://github.com/sgwoods/public.git ~/Projects-All/public
+```
+
+Then open:
+
+- `PUBLIC-OPERATING-MODEL.md`
+- `PROJECT-STATE-AND-RECOVERY.md`
+- `ARCHIVE_PROJECT_INTERFACE.md`
+- `PUBLIC_STATUS_INTERFACE.md`
+
+## What is safe right now
+
+The safest current continuity state is:
+
+- remote branch: `codex/public-recovery-stabilization`
+- canonical active local continuity workspace:
+  - `/Users/stevenwoods/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public-quack-recovery`
+
+That iCloud-backed checkout has already been validated to:
+
+- exist on the recovery branch
+- contain the current Quack continuity and workspace-status docs
+- pass `python3 quack/tools/quack_research_pipeline.py validate`
+- remain clean after validation
+
+The older checkout on this MacBook:
+
+- `/Users/stevenwoods/GitPages/public`
+
+is **deprecated for active local archive work** and still contains unrelated local modifications outside the continuity lane.
+
+## Current branch reality
+
+At the `2026-05-07` audit point:
+
+- `codex/public-recovery-stabilization` is `18` commits ahead of `origin/main`
+- `origin/main` is `223` commits ahead of `codex/public-recovery-stabilization`
+
+Interpretation:
+
+- the recovery branch is the safest continuity lane
+- it is not yet the same thing as “everything current on main”
+- new-machine continuity should start from the recovery branch on purpose
+
+## Verified local toolchain on the retiring MacBook
+
+These tools were present and working during the portability audit:
+
+- `git 2.50.1`
+- `python3 3.14.2`
+- `jq 1.7.1`
+- `rg 15.1.0`
+- `gs` / Ghostscript `10.06.0`
+
+Those are the expected baseline tools for the bootstrap and validation path.
+
+## Archive payload sizes from the retiring MacBook
+
+These give a rough expectation for cloned content already tracked in git:
+
+- `Spectra/`: about `84M`
+- `steven-woods-research/`: about `4.8M`
+- `quack/`: about `1.5M`
+- `kinitos-neoedge/`: about `304K`
+
+## Active-clone bootstrap path
+
+### 1. Run the full setup script
+
+From any checkout that already contains this script, run:
+
+```bash
+bash tools/start_codex_on_new_mac.sh setup
+```
+
+What `setup` does now:
+
+- installs Homebrew if needed
+- installs required command-line tools if missing:
+  - `git`
+  - `python3`
+  - `jq`
+  - `rg`
+  - `gs`
+- clones or refreshes the preferred active checkout at `~/Projects-All/public` by default
+- validates the checkout until it is usable
+
+If you want a different target location:
+
+```bash
+bash tools/start_codex_on_new_mac.sh setup "/custom/target/path"
+```
+
+### 2. Run validation again if desired
+
+After setup completes, you can rerun validation directly from the active checkout:
+
+```bash
+bash "$HOME/Projects-All/public/tools/start_codex_on_new_mac.sh" validate
+```
+
+### 3. Open the shared-public operating notes first
+
+Open these before doing any substantial work:
+
+- `PUBLIC-OPERATING-MODEL.md`
+- `PROJECT-STATE-AND-RECOVERY.md`
+- `ARCHIVE_PROJECT_INTERFACE.md`
+- `PUBLIC_STATUS_INTERFACE.md`
+- `quack/WORKSPACE-STATUS.md`
+- `kinitos-neoedge/WORKSPACE-STATUS.md`
+
+## Recovery-lane bootstrap path
+
+Use this only when you intentionally want the continuity/reconciliation lane:
+
+```bash
+bash tools/start_codex_on_new_mac.sh setup-recovery
+```
+
+If you want to revalidate an existing recovery checkout:
+
+```bash
+bash "$HOME/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public-quack-recovery/tools/start_codex_on_new_mac.sh" validate-recovery
+```
+
+## Sibling repos for full dashboard fidelity
+
+The repo itself is usable without sibling repositories, but the top-level coding activity charts are more complete when these local repos are also present:
+
+- Aurora:
+  - default path: `/Users/stevenwoods/Documents/Codex-Test1`
+  - override: `PUBLIC_AURORA_REPO`
+- PhD renovation:
+  - default path: `/Users/stevenwoods/phd-renovation`
+  - override: `PUBLIC_PHD_REPO`
+- MMath renovation:
+  - default path: `/Users/stevenwoods/mmath-renovation`
+  - override: `PUBLIC_MMATH_REPO`
+
+If these paths do not exist on the new Mac, the repo remains workable. Activity charts will simply show partial or zero counts for the missing coding projects until the overrides or sibling clones are provided.
+
+## What the start script validates
+
+The checked-in script at `tools/start_codex_on_new_mac.sh` verifies:
+
+- required commands exist or are installed during setup: `git`, `python3`, `jq`, `rg`, `gs`
+- the checkout is on the expected branch for the selected mode:
+  - `main` for `validate`
+  - `codex/public-recovery-stabilization` for `validate-recovery`
+- the checkout is clean
+- key files for the selected mode exist
+- Python entry points compile:
+  - `quack/tools/quack_research_pipeline.py`
+  - `tools/render_index.py`
+  - `tools/render_publications.py`
+  - `tools/render_steven_sources.py`
+  - `tools/render_steven_cv.py`
+- Quack archive validation passes:
+  - `python3 quack/tools/quack_research_pipeline.py validate`
+- sibling repo locations are reported for dashboard/chart fidelity
+- the relevant branch can be compared against `origin/main` even from a single-branch clone
+
+It was rerun successfully against the canonical iCloud-backed checkout during this portability pass.
+
+It also passed from a fresh remote clone on `2026-05-03`, proving that the checked-in recovery lane can recreate itself without depending on hidden state in the retiring MacBook checkout.
+
+The current `setup` + `validate` path is intended to be the one-command bootstrap for the preferred active shared-public clone on a replacement Mac.
+
+The `setup-recovery` + `validate-recovery` path remains the continuity-lane bootstrap when that older reconciliation workspace is still needed.
+
+The full `setup` path was rerun successfully against the canonical iCloud-backed checkout on `2026-05-04`, confirming that dependency install/repair, checkout refresh, and validation can complete in one flow.
+
+## What is still not fully settled
+
+Even after portability hardening, these things are still true:
+
+- the recovery branch has not yet been reconciled with `origin/main`
+- the deprecated non-iCloud MacBook checkout still contains unrelated local edits
+- not every Quack source has a local mirrored copy
+- broader whole-repo continuity beyond the active recovery branch still deserves deliberate review
+
+## Practical retirement rule for this MacBook
+
+Before treating this MacBook as fully retired:
+
+1. run `tools/start_codex_on_new_mac.sh setup` on the new Mac
+2. run `tools/start_codex_on_new_mac.sh validate` once more if you want a second confirmation
+3. open the shared-public operating notes successfully
+4. confirm the new Mac's `~/Projects-All/public` checkout is clean
+5. optionally run `tools/start_codex_on_new_mac.sh setup-recovery` if you still want the older continuity lane available
+6. do at least one small intentional continuation step there
+
+After that, treat this MacBook’s non-iCloud checkout as historical reference only, not the live source of truth.

--- a/tools/start_codex_on_new_mac.sh
+++ b/tools/start_codex_on_new_mac.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_URL="https://github.com/sgwoods/public.git"
+ACTIVE_BRANCH="main"
+ACTIVE_TARGET="${HOME}/Projects-All/public"
+RECOVERY_BRANCH="codex/public-recovery-stabilization"
+RECOVERY_TARGET="${HOME}/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public-quack-recovery"
+HOMEBREW_INSTALL_URL="https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+
+usage() {
+  cat <<EOF
+Usage:
+  $(basename "$0") install
+  $(basename "$0") setup [target_dir]
+  $(basename "$0") validate [target_dir]
+  $(basename "$0") setup-recovery [target_dir]
+  $(basename "$0") validate-recovery [target_dir]
+
+Defaults:
+  active branch: ${ACTIVE_BRANCH}
+  active target_dir: ${ACTIVE_TARGET}
+  recovery branch: ${RECOVERY_BRANCH}
+  recovery target_dir: ${RECOVERY_TARGET}
+
+Commands:
+  install            Install or repair the required local toolchain for a new Mac.
+  setup              Install prerequisites, clone or refresh the preferred active checkout on ${ACTIVE_BRANCH}, then validate it.
+  validate           Validate an existing preferred active checkout without changing tracked files.
+  setup-recovery     Install prerequisites, clone or refresh the recovery checkout, then validate it.
+  validate-recovery  Validate an existing recovery checkout without changing tracked files.
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+print_header() {
+  printf "\n== %s ==\n" "$1"
+}
+
+brew_bin() {
+  if command -v brew >/dev/null 2>&1; then
+    command -v brew
+    return 0
+  fi
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    echo /opt/homebrew/bin/brew
+    return 0
+  fi
+  if [[ -x /usr/local/bin/brew ]]; then
+    echo /usr/local/bin/brew
+    return 0
+  fi
+  return 1
+}
+
+refresh_shell_path_from_brew() {
+  local brew_path
+  brew_path="$(brew_bin 2>/dev/null || true)"
+  if [[ -n "$brew_path" ]]; then
+    eval "$("$brew_path" shellenv)"
+    hash -r
+  fi
+}
+
+ensure_homebrew() {
+  if brew_bin >/dev/null 2>&1; then
+    refresh_shell_path_from_brew
+    return 0
+  fi
+
+  print_header "Installing Homebrew"
+  require_cmd curl
+  NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL "$HOMEBREW_INSTALL_URL")"
+  refresh_shell_path_from_brew
+
+  if ! brew_bin >/dev/null 2>&1; then
+    echo "Homebrew installation did not complete successfully." >&2
+    exit 1
+  fi
+}
+
+ensure_brew_package() {
+  local package="$1"
+  local command_name="$2"
+  local brew_path
+  brew_path="$(brew_bin)"
+
+  if command -v "$command_name" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  print_header "Installing ${package}"
+  "$brew_path" install "$package"
+  refresh_shell_path_from_brew
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Expected command '$command_name' after installing package '$package', but it is still unavailable." >&2
+    exit 1
+  fi
+}
+
+install_required_toolchain() {
+  print_header "Installing required toolchain"
+
+  ensure_homebrew
+  ensure_brew_package git git
+  ensure_brew_package python python3
+  ensure_brew_package jq jq
+  ensure_brew_package ripgrep rg
+  ensure_brew_package ghostscript gs
+}
+
+check_optional_tools() {
+  print_header "Optional tool visibility"
+  if command -v gs >/dev/null 2>&1; then
+    gs --version | head -n 1
+  else
+    echo "Ghostscript (gs) not found; steven-woods-cv.pdf can remain checked in, but local regeneration will be unavailable until gs is installed."
+  fi
+}
+
+report_dashboard_repo_paths() {
+  print_header "Dashboard sibling repos"
+  local aurora="${PUBLIC_AURORA_REPO:-$HOME/Documents/Codex-Test1}"
+  local phd="${PUBLIC_PHD_REPO:-$HOME/phd-renovation}"
+  local mmath="${PUBLIC_MMATH_REPO:-$HOME/mmath-renovation}"
+
+  for label_and_path in \
+    "Aurora:$aurora" \
+    "PhD renovation:$phd" \
+    "MMath renovation:$mmath"; do
+    local label="${label_and_path%%:*}"
+    local path="${label_and_path#*:}"
+    if [[ -d "$path/.git" ]]; then
+      echo "$label repo found: $path"
+    else
+      echo "$label repo not found: $path"
+    fi
+  done
+}
+
+fetch_public_refs() {
+  local target="$1"
+
+  git -C "$target" fetch origin \
+    "main:refs/remotes/origin/main" \
+    "$RECOVERY_BRANCH:refs/remotes/origin/$RECOVERY_BRANCH" >/dev/null
+}
+
+ensure_clean_checkout() {
+  local target="$1"
+  local dirty
+
+  dirty="$(git -C "$target" status --porcelain)"
+  if [[ -n "$dirty" ]]; then
+    echo "Checkout is not clean:" >&2
+    printf "%s\n" "$dirty" >&2
+    exit 1
+  fi
+}
+
+validate_checkout() {
+  local mode="$1"
+  local target="$2"
+  local expected_branch
+  local mode_label
+  local divergence_label
+  local divergence_range
+  local relpath
+  local -a required_files
+  local -a suggested_files
+
+  case "$mode" in
+    active)
+      expected_branch="$ACTIVE_BRANCH"
+      mode_label="active"
+      divergence_label="active-branch divergence"
+      divergence_range="origin/main...HEAD"
+      required_files=(
+        "ARCHIVE_PROJECT_INTERFACE.md"
+        "PUBLIC_STATUS_INTERFACE.md"
+        "README.md"
+        "index.html"
+        "tools/render_index.py"
+        "tools/render_publications.py"
+        "tools/render_steven_sources.py"
+        "tools/render_steven_cv.py"
+        "quack/tools/quack_research_pipeline.py"
+      )
+      suggested_files=(
+        "PUBLIC-OPERATING-MODEL.md"
+        "README.md"
+        "ARCHIVE_PROJECT_INTERFACE.md"
+        "PUBLIC_STATUS_INTERFACE.md"
+      )
+      ;;
+    recovery)
+      expected_branch="$RECOVERY_BRANCH"
+      mode_label="recovery"
+      divergence_label="recovery-branch divergence"
+      divergence_range="origin/main...origin/$RECOVERY_BRANCH"
+      required_files=(
+        "ARCHIVE_PROJECT_INTERFACE.md"
+        "PROJECT-STATE-AND-RECOVERY.md"
+        "START-HERE-NEW-MAC.md"
+        "LOCAL-WORKTREE-STATUS.md"
+        "quack/PROJECT-STATE-AND-RECOVERY.md"
+        "quack/WORKSPACE-STATUS.md"
+        "quack/tools/quack_research_pipeline.py"
+        "data/shared/company-research-workflow.md"
+        "kinitos-neoedge/WORKSPACE-STATUS.md"
+      )
+      suggested_files=(
+        "PROJECT-STATE-AND-RECOVERY.md"
+        "quack/PROJECT-STATE-AND-RECOVERY.md"
+        "quack/WORKSPACE-STATUS.md"
+      )
+      ;;
+    *)
+      echo "Unknown validation mode: $mode" >&2
+      exit 1
+      ;;
+  esac
+
+  require_cmd git
+  require_cmd python3
+  require_cmd jq
+  require_cmd rg
+
+  print_header "Validating ${mode_label} checkout"
+
+  if [[ ! -d "$target/.git" ]]; then
+    echo "Not a git checkout: $target" >&2
+    exit 1
+  fi
+
+  local current_branch
+  current_branch="$(git -C "$target" rev-parse --abbrev-ref HEAD)"
+  if [[ "$current_branch" != "$expected_branch" ]]; then
+    echo "Expected branch $expected_branch but found $current_branch" >&2
+    exit 1
+  fi
+
+  fetch_public_refs "$target"
+  ensure_clean_checkout "$target"
+
+  for relpath in "${required_files[@]}"; do
+    if [[ ! -f "$target/$relpath" ]]; then
+      echo "Missing required file: $relpath" >&2
+      exit 1
+    fi
+  done
+
+  print_header "Checking toolchain"
+  git --version
+  python3 --version
+  jq --version
+  rg --version | head -n 1
+  check_optional_tools
+
+  print_header "Compiling Python entry points"
+  python3 -m py_compile \
+    "$target/quack/tools/quack_research_pipeline.py" \
+    "$target/tools/render_index.py" \
+    "$target/tools/render_publications.py" \
+    "$target/tools/render_steven_sources.py" \
+    "$target/tools/render_steven_cv.py"
+
+  print_header "Running Quack validation"
+  python3 "$target/quack/tools/quack_research_pipeline.py" validate
+
+  report_dashboard_repo_paths
+
+  print_header "Checking ${divergence_label}"
+  git -C "$target" rev-list --left-right --count "$divergence_range"
+
+  print_header "Checkout status"
+  git -C "$target" status --short --branch
+
+  print_header "Validation complete"
+  cat <<EOF
+Validated checkout:
+  $target
+
+Suggested next files to open:
+EOF
+
+  for relpath in "${suggested_files[@]}"; do
+    if [[ -f "$target/$relpath" ]]; then
+      printf "  %s/%s\n" "$target" "$relpath"
+    fi
+  done
+}
+
+setup_checkout() {
+  local mode="$1"
+  local target="$2"
+  local branch
+  local mode_label
+
+  case "$mode" in
+    active)
+      branch="$ACTIVE_BRANCH"
+      mode_label="active"
+      ;;
+    recovery)
+      branch="$RECOVERY_BRANCH"
+      mode_label="recovery"
+      ;;
+    *)
+      echo "Unknown setup mode: $mode" >&2
+      exit 1
+      ;;
+  esac
+
+  install_required_toolchain
+
+  local parent
+  parent="$(dirname "$target")"
+  mkdir -p "$parent"
+
+  if [[ -d "$target/.git" ]]; then
+    print_header "Refreshing existing ${mode_label} checkout"
+    ensure_clean_checkout "$target"
+    fetch_public_refs "$target"
+    git -C "$target" checkout "$branch"
+    git -C "$target" pull --ff-only origin "$branch"
+  else
+    print_header "Cloning ${mode_label} checkout"
+    git clone --branch "$branch" --single-branch "$REPO_URL" "$target"
+  fi
+
+  validate_checkout "$mode" "$target"
+}
+
+main() {
+  local command="${1:-}"
+  local target
+
+  case "$command" in
+    install)
+      install_required_toolchain
+      ;;
+    setup)
+      target="${2:-$ACTIVE_TARGET}"
+      setup_checkout active "$target"
+      ;;
+    validate)
+      target="${2:-$ACTIVE_TARGET}"
+      validate_checkout active "$target"
+      ;;
+    setup-recovery)
+      target="${2:-$RECOVERY_TARGET}"
+      setup_checkout recovery "$target"
+      ;;
+    validate-recovery)
+      target="${2:-$RECOVERY_TARGET}"
+      validate_checkout recovery "$target"
+      ;;
+    ""|-h|--help|help)
+      usage
+      ;;
+    *)
+      echo "Unknown command: $command" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
Isolates the shared public-layer operating model, distinguishes standalone project exports from shared-public subprojects, and updates the new-Mac bootstrap flow so the preferred active clone is ~/Projects-All/public while preserving an explicit recovery lane.