### PR TITLE
Ignore Python bytecode caches in public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 **/.DS_Store
+
+__pycache__/
+**/__pycache__/
+*.pyc


### PR DESCRIPTION
Adds standard Python bytecode ignore rules so validation does not leave __pycache__ directories as untracked files.