### PR TITLE
Clarify post-migration public clone model and deprecation state

### DIFF
--- a/PROJECT-STATE-AND-RECOVERY.md
+++ b/PROJECT-STATE-AND-RECOVERY.md
@@ -1,6 +1,6 @@
 # Public project state and recovery
 
-Updated: 2026-05-07
+Updated: 2026-05-09
 
 ## Current recommended working model
 
@@ -26,6 +26,7 @@ Important distinction:
 - `public-quack-recovery` remains a continuity and reconciliation lane
 - it is not the preferred default active clone model for ongoing shared-public work
 - `/Users/stevenwoods/GitPages/public` remains a deprecated transition checkout
+- `main` in `~/Projects-All/public` is now the normal active working state for this repo
 
 Read the remaining sections in this file as the history of the recovery pass
 that created the continuity lane, not as the final long-term clone model.
@@ -34,6 +35,8 @@ that created the continuity lane, not as the final long-term clone model.
 
 During the recovery pass, the working policy was that local work should happen
 only in an iCloud-backed folder.
+
+This section describes the optional continuity lane and older supporting checkouts, not the default active clone.
 
 Current state:
 
@@ -182,10 +185,10 @@ These are the current canonical working areas inside this repo:
 
 These are the areas that should be treated as current working surfaces unless later documents explicitly replace them.
 
-Workspace-status references:
+Current orientation references:
 
-- `quack/WORKSPACE-STATUS.md`
-- `kinitos-neoedge/WORKSPACE-STATUS.md`
+- `README.md`
+- `PUBLIC-OPERATING-MODEL.md`
 - `START-HERE-NEW-MAC.md`
 
 ## Legacy, alias, or supporting areas
@@ -300,8 +303,8 @@ Checked in and reusable from a clean clone:
 
 Notable continuity-positive signals:
 
-- Quack already has a dedicated checked-in recovery note at `quack/PROJECT-STATE-AND-RECOVERY.md`
-- shared workflow guidance exists at `data/shared/company-research-workflow.md`
+- the top-level migration/startup guidance is checked in under `README.md`, `PUBLIC-OPERATING-MODEL.md`, and `START-HERE-NEW-MAC.md`
+- shared workflow guidance exists at `data/shared/incoming-artifact-analysis-playbook.md` and `data/shared/incoming-artifact-analysis-template.md`
 - person/archive contract guidance exists in `ARCHIVE_PROJECT_INTERFACE.md`
 
 ## What is not safely checked in yet
@@ -365,7 +368,7 @@ Current hygiene rule:
 - not all external sources have local mirrors
 - some research notes still depend on canonical web URLs instead of preserved local copies
 - several active areas are only partially checked in because the current working tree is dirty
-- remote `origin/main` is ahead of the local checkout, so this local workspace is not even the full checked-in truth as of today
+- remote `origin/main` can drift ahead of a local checkout, so the active clone should be verified against GitHub before treating a local snapshot as authoritative
 
 ### Continuity conclusion
 
@@ -399,7 +402,7 @@ What would still be at risk are only the active parallel project edits that rema
    - canonical external only
    - needs local preservation
 8. Decide which artifacts are canonical repo content versus machine-local scratch output.
-9. Keep `README.md`, `START-HERE-NEW-MAC.md`, and `LOCAL-WORKTREE-STATUS.md` aligned so a new machine has one obvious startup path.
+9. Keep `README.md`, `PUBLIC-OPERATING-MODEL.md`, and `START-HERE-NEW-MAC.md` aligned so a new machine has one obvious startup path.
 
 ## Recommended next steps for the project itself
 

--- a/PUBLIC-OPERATING-MODEL.md
+++ b/PUBLIC-OPERATING-MODEL.md
@@ -1,6 +1,6 @@
 # Public Repo Operating Model
 
-Updated: `2026-05-07`
+Updated: `2026-05-09`
 
 This file defines the intended ongoing role of `sgwoods/public`.
 
@@ -40,7 +40,7 @@ Use these classes consistently when deciding where work belongs.
 | Shared navigation and reporting layer | Cross-project homepage, shared assets, shared renderers, shared workflow docs | `index.html`, `assets/`, `tools/render_index.py`, `data/shared/`, `README.md`, `PUBLIC_STATUS_INTERFACE.md`, `ARCHIVE_PROJECT_INTERFACE.md` | Owned by the `public` repo itself |
 | Standalone project exports and summary cards | Public pages and status manifests published in from true standalone repos | `data/projects/aurora-galactica.json`, `data/projects/phd-renovation.json`, `data/projects/mmath-renovation.json`, `data/projects/ai-dystopia-quotes.json`, top-level pages such as `phd-renovation.html`, `phd-renovation-dashboard.html`, `phd-renovation-handbook.html`, `mmath-renovation.html`, `aurora-galactica.html` | Owned by the originating standalone repo; `public` only renders and presents them |
 | Shared-public subprojects | Deep archive/research areas that still live inside `public` as subdirectories | `steven-woods-research/`, `quack/`, `kinitos-neoedge/`, `canberra-research/`, `google-canada-research/`, `inovia-research/`, `sei-pittsburgh-research/` plus their top-level landing pages | Maintained inside the canonical `public` clone unless deliberately split into separate repos later |
-| Legacy, compatibility, or deprecated patterns | Transitional aliases, duplicate publication paths, or older local clone habits that should not expand casually | `data/projects/codex-test1.json`, `codex-test1.html`, the bridge `data/projects/quack-com.json`, the bridge `data/projects/kinitos-neoedge.json`, older sparse single-purpose local clones of `public`, deprecated `/Users/stevenwoods/GitPages/public` checkout, recovery-only iCloud clone conventions | Keep only when needed for continuity or compatibility; label them clearly |
+| Legacy, compatibility, or deprecated patterns | Transitional aliases, duplicate publication paths, or older local clone habits that should not expand casually | `data/projects/codex-test1.json`, `codex-test1.html`, the bridge `data/projects/quack-com.json`, the bridge `data/projects/kinitos-neoedge.json`, older sparse single-purpose local clones of `public`, deprecated `/Users/stevenwoods/GitPages/public` checkout, optional recovery-lane iCloud clones | Keep only when needed for continuity or compatibility; label them clearly |
 
 ## Ongoing ownership model
 
@@ -100,8 +100,10 @@ For the newer machine and for ongoing work going forward, the preferred active c
 Interpretation:
 
 - `Projects-All/public` is the canonical active working clone for the shared public layer
+- `main` is the normal working branch for that preferred active clone
 - true standalone repos should each have their own sibling working clone under `Projects-All`
 - shared-public subprojects should normally be edited inside `Projects-All/public`
+- recovery-only or reconciliation branches should be used only intentionally
 - do not casually create extra top-level clones for `quack`, `steven-woods-research`, `google-canada-research`, and similar subprojects unless there is a deliberate operational reason
 
 Recommended `Projects-All` shape:

--- a/PUBLIC_STATUS_INTERFACE.md
+++ b/PUBLIC_STATUS_INTERFACE.md
@@ -5,7 +5,7 @@ for the shared public homepage in this repository.
 
 The shared homepage is:
 
-- [/Users/stevenwoods/GitPages/public/index.html](/Users/stevenwoods/GitPages/public/index.html)
+- [`index.html`](index.html)
 
 That file is shared and must not be edited directly by independent project
 update flows.
@@ -65,7 +65,7 @@ Each project may update:
 
 Each project must not update:
 
-- [/Users/stevenwoods/GitPages/public/index.html](/Users/stevenwoods/GitPages/public/index.html)
+- [`index.html`](index.html)
 - any other project's status manifest
 
 The `public` project alone is responsible for rendering `index.html` from the
@@ -188,7 +188,7 @@ Each project's automation may do the following:
 
 A project updater must not:
 
-- edit [/Users/stevenwoods/GitPages/public/index.html](/Users/stevenwoods/GitPages/public/index.html)
+- edit [`index.html`](index.html)
 - edit another project's JSON file
 - rewrite homepage wording directly
 - reorder homepage entries
@@ -207,11 +207,11 @@ That renderer will:
 - render homepage entries in a fixed order
 - compute the homepage "Repository work last updated" value from the maximum
   `repo_pushed_at`
-- generate [/Users/stevenwoods/GitPages/public/index.html](/Users/stevenwoods/GitPages/public/index.html)
+- generate [`index.html`](index.html)
 
 Current renderer path:
 
-- [/Users/stevenwoods/GitPages/public/tools/render_index.py](/Users/stevenwoods/GitPages/public/tools/render_index.py)
+- [`tools/render_index.py`](tools/render_index.py)
 
 ## Suggested Homepage Sentence Template
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ It is not just a standalone project site. Its job is to provide one clear public
 - published exports from standalone repos
 - shared-public archive and research subprojects that still live inside this repo
 
-Start here on any machine:
+Start here in this repo:
 
-- [PUBLIC-OPERATING-MODEL.md](/Users/stevenwoods/GitPages/public/PUBLIC-OPERATING-MODEL.md)
-- [PROJECT-STATE-AND-RECOVERY.md](/Users/stevenwoods/GitPages/public/PROJECT-STATE-AND-RECOVERY.md)
-- [START-HERE-NEW-MAC.md](/Users/stevenwoods/GitPages/public/START-HERE-NEW-MAC.md)
-- [LOCAL-WORKTREE-STATUS.md](/Users/stevenwoods/GitPages/public/LOCAL-WORKTREE-STATUS.md)
-- [ARCHIVE_PROJECT_INTERFACE.md](/Users/stevenwoods/GitPages/public/ARCHIVE_PROJECT_INTERFACE.md)
-- [PUBLIC_STATUS_INTERFACE.md](/Users/stevenwoods/GitPages/public/PUBLIC_STATUS_INTERFACE.md)
+- [PUBLIC-OPERATING-MODEL.md](PUBLIC-OPERATING-MODEL.md)
+- [PROJECT-STATE-AND-RECOVERY.md](PROJECT-STATE-AND-RECOVERY.md)
+- [START-HERE-NEW-MAC.md](START-HERE-NEW-MAC.md)
+- [ARCHIVE_PROJECT_INTERFACE.md](ARCHIVE_PROJECT_INTERFACE.md)
+- [PUBLIC_STATUS_INTERFACE.md](PUBLIC_STATUS_INTERFACE.md)
 
 Current important rule:
 
-- the preferred active clone on the newer machine is `~/Projects-All/public`
-- this `/Users/stevenwoods/GitPages/public` checkout is transitional and should be treated as a historical bridge checkout
+- the preferred active shared-public clone is `~/Projects-All/public` on `main`
+- the older continuity/recovery lane is optional and should be used only for deliberate reconciliation work
+- `/Users/stevenwoods/GitPages/public` is a deprecated historical bridge checkout, not the normal active location
 - older iCloud recovery clones remain useful for continuity and reconciliation, but they are not the preferred default active clone model for ongoing shared-public work

--- a/START-HERE-NEW-MAC.md
+++ b/START-HERE-NEW-MAC.md
@@ -2,7 +2,9 @@
 
 Updated: `2026-05-09`
 
-This file is the portability handoff for bringing the `public` continuity workspace onto a different Mac without relying on memory from the retiring MacBook.
+This file is the portability handoff for bringing the shared `public` workspace onto a different Mac without relying on memory from the retiring MacBook.
+
+The normal target is the preferred active clone at `~/Projects-All/public` on `main`. The older recovery lane remains available for deliberate continuity and reconciliation work, but it is not the default path.
 
 ## Preferred active clone model
 
@@ -38,7 +40,9 @@ Then open:
 
 ## What is safe right now
 
-The safest current continuity state is:
+For normal day-to-day work, use `~/Projects-All/public` on `main`.
+
+The notes below describe the optional continuity/recovery lane:
 
 - remote branch: `codex/public-recovery-stabilization`
 - canonical active local continuity workspace:
@@ -47,7 +51,7 @@ The safest current continuity state is:
 That iCloud-backed checkout has already been validated to:
 
 - exist on the recovery branch
-- contain the current Quack continuity and workspace-status docs
+- contain the current checked-in continuity and migration docs
 - pass `python3 quack/tools/quack_research_pipeline.py validate`
 - remain clean after validation
 
@@ -132,11 +136,12 @@ bash "$HOME/Projects-All/public/tools/start_codex_on_new_mac.sh" validate
 Open these before doing any substantial work:
 
 - `PUBLIC-OPERATING-MODEL.md`
+- `README.md`
 - `PROJECT-STATE-AND-RECOVERY.md`
 - `ARCHIVE_PROJECT_INTERFACE.md`
 - `PUBLIC_STATUS_INTERFACE.md`
-- `quack/WORKSPACE-STATUS.md`
-- `kinitos-neoedge/WORKSPACE-STATUS.md`
+- `quack/README.md`
+- `kinitos-neoedge/README.md`
 
 ## Recovery-lane bootstrap path
 
@@ -157,14 +162,17 @@ bash "$HOME/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public-quac
 The repo itself is usable without sibling repositories, but the top-level coding activity charts are more complete when these local repos are also present:
 
 - Aurora:
-  - default path: `/Users/stevenwoods/Documents/Codex-Test1`
-  - override: `PUBLIC_AURORA_REPO`
+  - default path: `~/Projects-All/Codex-Test1`
+  - preferred override: `PUBLIC_AURORA_REPO_PATH`
+  - legacy override still accepted by the start script: `PUBLIC_AURORA_REPO`
 - PhD renovation:
-  - default path: `/Users/stevenwoods/phd-renovation`
-  - override: `PUBLIC_PHD_REPO`
+  - default path: `~/Projects-All/phd-renovation-working`
+  - preferred override: `PUBLIC_PHD_REPO_PATH`
+  - legacy override still accepted by the start script: `PUBLIC_PHD_REPO`
 - MMath renovation:
-  - default path: `/Users/stevenwoods/mmath-renovation`
-  - override: `PUBLIC_MMATH_REPO`
+  - default path: `~/Projects-All/mmath-renovation-working`
+  - preferred override: `PUBLIC_MMATH_REPO_PATH`
+  - legacy override still accepted by the start script: `PUBLIC_MMATH_REPO`
 
 If these paths do not exist on the new Mac, the repo remains workable. Activity charts will simply show partial or zero counts for the missing coding projects until the overrides or sibling clones are provided.
 
@@ -189,7 +197,7 @@ The checked-in script at `tools/start_codex_on_new_mac.sh` verifies:
 - sibling repo locations are reported for dashboard/chart fidelity
 - the relevant branch can be compared against `origin/main` even from a single-branch clone
 
-It was rerun successfully against the canonical iCloud-backed checkout during this portability pass.
+It was rerun successfully during this portability pass.
 
 It also passed from a fresh remote clone on `2026-05-03`, proving that the checked-in recovery lane can recreate itself without depending on hidden state in the retiring MacBook checkout.
 
@@ -197,7 +205,7 @@ The current `setup` + `validate` path is intended to be the one-command bootstra
 
 The `setup-recovery` + `validate-recovery` path remains the continuity-lane bootstrap when that older reconciliation workspace is still needed.
 
-The full `setup` path was rerun successfully against the canonical iCloud-backed checkout on `2026-05-04`, confirming that dependency install/repair, checkout refresh, and validation can complete in one flow.
+The full `setup` path was rerun successfully during the migration pass, confirming that dependency install/repair, checkout refresh, and validation can complete in one flow for the preferred active clone.
 
 ## What is still not fully settled
 

--- a/tools/start_codex_on_new_mac.sh
+++ b/tools/start_codex_on_new_mac.sh
@@ -128,9 +128,9 @@ check_optional_tools() {
 
 report_dashboard_repo_paths() {
   print_header "Dashboard sibling repos"
-  local aurora="${PUBLIC_AURORA_REPO:-$HOME/Documents/Codex-Test1}"
-  local phd="${PUBLIC_PHD_REPO:-$HOME/phd-renovation}"
-  local mmath="${PUBLIC_MMATH_REPO:-$HOME/mmath-renovation}"
+  local aurora="${PUBLIC_AURORA_REPO_PATH:-${PUBLIC_AURORA_REPO:-$HOME/Projects-All/Codex-Test1}}"
+  local phd="${PUBLIC_PHD_REPO_PATH:-${PUBLIC_PHD_REPO:-$HOME/Projects-All/phd-renovation-working}}"
+  local mmath="${PUBLIC_MMATH_REPO_PATH:-${PUBLIC_MMATH_REPO:-$HOME/Projects-All/mmath-renovation-working}}"
 
   for label_and_path in \
     "Aurora:$aurora" \
@@ -208,19 +208,23 @@ validate_checkout() {
       divergence_range="origin/main...origin/$RECOVERY_BRANCH"
       required_files=(
         "ARCHIVE_PROJECT_INTERFACE.md"
+        "README.md"
         "PROJECT-STATE-AND-RECOVERY.md"
         "START-HERE-NEW-MAC.md"
-        "LOCAL-WORKTREE-STATUS.md"
-        "quack/PROJECT-STATE-AND-RECOVERY.md"
-        "quack/WORKSPACE-STATUS.md"
+        "PUBLIC-OPERATING-MODEL.md"
+        "quack/README.md"
         "quack/tools/quack_research_pipeline.py"
-        "data/shared/company-research-workflow.md"
-        "kinitos-neoedge/WORKSPACE-STATUS.md"
+        "kinitos-neoedge/README.md"
+        "data/shared/incoming-artifact-analysis-playbook.md"
+        "data/shared/incoming-artifact-analysis-template.md"
       )
       suggested_files=(
+        "README.md"
+        "PUBLIC-OPERATING-MODEL.md"
         "PROJECT-STATE-AND-RECOVERY.md"
-        "quack/PROJECT-STATE-AND-RECOVERY.md"
-        "quack/WORKSPACE-STATUS.md"
+        "START-HERE-NEW-MAC.md"
+        "quack/README.md"
+        "kinitos-neoedge/README.md"
       )
       ;;
     *)


### PR DESCRIPTION
Tightens the post-migration public repo guidance so the preferred active clone is ~/Projects-All/public on main, keeps the old-machine checkout explicitly deprecated, removes broken/missing orientation references, and aligns the new-Mac bootstrap/validation docs and script with the current operating model.